### PR TITLE
SonarCloud scanner now uses Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ install:
 - true
 script:
 - mvn install -Dmaven.javadoc.skip=true -B -V
-# SonarQube needs to be run with at least Java 8; also make sure we are on the correct branch
+# SonarCloud scanner needs to be run with at least Java 11; also make sure we are on the correct branch
 after_success:
-- if [[ $TRAVIS_JDK_VERSION == openjdk8 && $TRAVIS_BRANCH == dev ]]; then
+- if [[ $TRAVIS_JDK_VERSION == openjdk11 && $TRAVIS_BRANCH == dev ]]; then
     mvn sonar:sonar -Dsonar.organization=dannil-github -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONARQUBE_TOKEN;
   fi;
 


### PR DESCRIPTION
As required by SonarCloud before being deprecated February 1st.